### PR TITLE
Fixed setting weights to 0 for the offset vector and sigma channels

### DIFF
--- a/bpartis/models.py
+++ b/bpartis/models.py
@@ -191,10 +191,10 @@ class BranchedERFNet(nn.Module):
             print('initialize last layer with size: ',
                   output_conv.weight.size())
 
-            output_conv.weight[:, 0:2, :, :].fill_(0)
+            output_conv.weight[0:2, :, :, :].fill_(0)
             output_conv.bias[0:2].fill_(0)
 
-            output_conv.weight[:, 2:2+n_sigma, :, :].fill_(0)
+            output_conv.weight[2:2+n_sigma, :, :, :].fill_(0)
             output_conv.bias[2:2+n_sigma].fill_(1)
 
     def forward(self, input, only_encode=False):


### PR DESCRIPTION
When initializing the output convolutional layer, we want to set the weights of the offset vector channels and the sigma channels to 0. The shape of the output_conv.weight tensor is [out_channels, in_channels, kernel_size, kernel_size]. Thus, we need to modify the weight tensor at index 0.